### PR TITLE
feat: add --broadcast to agently-cli

### DIFF
--- a/packages/agently-cli/src/commands/register.test.ts
+++ b/packages/agently-cli/src/commands/register.test.ts
@@ -68,4 +68,8 @@ describe("register command validation", () => {
   test("localhost requires --registry flag", async () => {
     await expect(register({ chain: "localhost" })).rejects.toThrow("--registry is required for localhost");
   });
+
+  test("dry-run completes without wallet interaction when --broadcast is not set", async () => {
+    await expect(register({ chain: "sepolia", uri: "https://example.com/agent.json" })).resolves.toBeUndefined();
+  });
 });

--- a/packages/agently-cli/src/commands/register.ts
+++ b/packages/agently-cli/src/commands/register.ts
@@ -40,20 +40,34 @@ export async function register(options: RegisterOptions): Promise<void> {
     args: resolvedUri ? [resolvedUri] : [],
   });
 
+  const printTxDetails = (header: string) => {
+    console.log("");
+    console.log(chalk.dim(header));
+    console.log(`  ${label("To")}${registryAddress}`);
+    console.log(`  ${label("Data")}${data.slice(0, 10)}${chalk.dim("\u2026" + (data.length - 2) / 2 + " bytes")}`);
+    console.log(`  ${label("Chain")}${chainName}`);
+    console.log(`  ${label("Function")}${resolvedUri ? "register(string memory agentURI)" : "register()"}`);
+    if (resolvedUri) {
+      console.log(`  ${label("URI")}${truncateUri(resolvedUri)}`);
+    }
+    console.log("");
+  };
+
   validateBrowserRpcConflict(options.browser, options.rpcUrl);
+
+  if (!options.broadcast) {
+    if (options.browser || options.keystore || process.env.PRIVATE_KEY) {
+      console.warn("Note: --browser/--keystore/PRIVATE_KEY ignored in dry-run mode. Pass --broadcast to use a wallet.");
+    }
+    printTxDetails("Transaction details (dry-run)");
+    console.log("Dry-run complete. To sign and broadcast, re-run with --broadcast.");
+    return;
+  }
+
   const walletMethod = await selectWalletMethod(options);
   validateBrowserRpcConflict(walletMethod.type === "browser" || undefined, options.rpcUrl);
 
-  console.log("");
-  console.log(chalk.dim("Signing transaction..."));
-  console.log(`  ${label("To")}${registryAddress}`);
-  console.log(`  ${label("Data")}${data.slice(0, 10)}${chalk.dim("\u2026" + (data.length - 2) / 2 + " bytes")}`);
-  console.log(`  ${label("Chain")}${chainName}`);
-  console.log(`  ${label("Function")}${resolvedUri ? "register(string memory agentURI)" : "register()"}`);
-  if (resolvedUri) {
-    console.log(`  ${label("URI")}${truncateUri(resolvedUri)}`);
-  }
-  console.log("");
+  printTxDetails("Signing transaction...");
 
   const result = await signTransaction({
     walletMethod,

--- a/packages/agently-cli/src/commands/set-agent-uri.test.ts
+++ b/packages/agently-cli/src/commands/set-agent-uri.test.ts
@@ -116,6 +116,12 @@ describe("set-agent-uri command validation", () => {
     ).rejects.toThrow("--rpc-url cannot be used with browser wallet");
   });
 
+  test("dry-run completes without wallet interaction when --broadcast is not set", async () => {
+    await expect(
+      setAgentUri({ agentId: "1", uri: "https://example.com/agent.json", chain: "sepolia" }),
+    ).resolves.toBeUndefined();
+  });
+
   test("rejects invalid agent ID (negative)", async () => {
     await expect(
       setAgentUri({ agentId: "-1", uri: "https://example.com/agent.json", chain: "sepolia" }),

--- a/packages/agently-cli/src/commands/set-agent-uri.ts
+++ b/packages/agently-cli/src/commands/set-agent-uri.ts
@@ -83,19 +83,33 @@ export async function setAgentUri(options: SetAgentUriOptions): Promise<void> {
     args: [BigInt(agentId), resolvedUri],
   });
 
+  const printTxDetails = (header: string) => {
+    console.log("");
+    console.log(chalk.dim(header));
+    console.log(`  ${label("To")}${registryAddress}`);
+    console.log(`  ${label("Data")}${data.slice(0, 10)}${chalk.dim("\u2026" + (data.length - 2) / 2 + " bytes")}`);
+    console.log(`  ${label("Chain")}${chainName}`);
+    console.log(`  ${label("Function")}setAgentURI(uint256 agentId, string calldata newURI)`);
+    console.log(`  ${label("Agent ID")}${agentId}`);
+    console.log(`  ${label("URI")}${truncateUri(resolvedUri)}`);
+    console.log("");
+  };
+
   validateBrowserRpcConflict(options.browser, options.rpcUrl);
+
+  if (!options.broadcast) {
+    if (options.browser || options.keystore || process.env.PRIVATE_KEY) {
+      console.warn("Note: --browser/--keystore/PRIVATE_KEY ignored in dry-run mode. Pass --broadcast to use a wallet.");
+    }
+    printTxDetails("Transaction details (dry-run)");
+    console.log("Dry-run complete. To sign and broadcast, re-run with --broadcast.");
+    return;
+  }
+
   const walletMethod = await selectWalletMethod(options);
   validateBrowserRpcConflict(walletMethod.type === "browser" || undefined, options.rpcUrl);
 
-  console.log("");
-  console.log(chalk.dim("Signing transaction..."));
-  console.log(`  ${label("To")}${registryAddress}`);
-  console.log(`  ${label("Data")}${data.slice(0, 10)}${chalk.dim("\u2026" + (data.length - 2) / 2 + " bytes")}`);
-  console.log(`  ${label("Chain")}${chainName}`);
-  console.log(`  ${label("Function")}setAgentURI(uint256 agentId, string calldata newURI)`);
-  console.log(`  ${label("Agent ID")}${agentId}`);
-  console.log(`  ${label("URI")}${truncateUri(resolvedUri)}`);
-  console.log("");
+  printTxDetails("Signing transaction...");
 
   const result = await signTransaction({
     walletMethod,

--- a/packages/agently-cli/src/index.ts
+++ b/packages/agently-cli/src/index.ts
@@ -36,6 +36,7 @@ program
   .option("--registry <address>", "Contract address of the IdentityRegistry (required for localhost)")
   .option("--keystore <path>", "Path to Ethereum keystore (V3) JSON file for local signing")
   .option("--browser", "Use browser extension wallet (any extension)")
+  .option("--broadcast", "Sign and broadcast the transaction (default: dry-run)")
   .option("--out-dir <path>", "Write deployment result as JSON to the given directory")
   .addHelpText(
     "after",
@@ -77,6 +78,12 @@ Option Details:
       The wallet handles both signing and broadcasting the transaction.
       Cannot be combined with --rpc-url.
 
+  --broadcast
+      Sign and broadcast the transaction on-chain. Without this flag the
+      command performs a dry-run: it encodes the transaction and prints
+      its details but does not interact with any wallet or send anything
+      to the network.
+
   --out-dir <path>
       Directory to write the deployment result as a JSON file. The file
       is named registration-<chainId>-<timestamp>.json.
@@ -87,10 +94,14 @@ Environment Variables:
                  for interactive use as the key may appear in shell history.
 
 Examples:
-  $ agently-cli register --uri "./metadata.json" --chain sepolia --keystore ~/.foundry/keystores/default
-  $ PRIVATE_KEY=0x... agently-cli register --chain sepolia
-  $ agently-cli register --chain localhost --registry 0x5FbDB2315678afecb367f032d93F642f64180aa3 --uri "./metadata.json"
-  $ agently-cli register --uri "./metadata.json" --chain sepolia --browser`,
+  # Dry-run (default) — shows encoded transaction, no wallet needed
+  $ agently-cli register --uri "./metadata.json" --chain sepolia
+
+  # Sign and broadcast
+  $ agently-cli register --uri "./metadata.json" --chain sepolia --keystore ~/.foundry/keystores/default --broadcast
+  $ PRIVATE_KEY=0x... agently-cli register --chain sepolia --broadcast
+  $ agently-cli register --chain localhost --registry 0x5FbDB2315678afecb367f032d93F642f64180aa3 --uri "./metadata.json" --broadcast
+  $ agently-cli register --uri "./metadata.json" --chain sepolia --browser --broadcast`,
   )
   .action(handleAction(register));
 
@@ -104,6 +115,7 @@ program
   .option("--registry <address>", "Contract address of the IdentityRegistry (required for localhost)")
   .option("--keystore <path>", "Path to Ethereum keystore (V3) JSON file for local signing")
   .option("--browser", "Use browser extension wallet (any extension)")
+  .option("--broadcast", "Sign and broadcast the transaction (default: dry-run)")
   .option("--out-dir <path>", "Write result as JSON to the given directory")
   .addHelpText(
     "after",
@@ -151,6 +163,12 @@ Option Details:
       The wallet handles both signing and broadcasting the transaction.
       Cannot be combined with --rpc-url.
 
+  --broadcast
+      Sign and broadcast the transaction on-chain. Without this flag the
+      command performs a dry-run: it encodes the transaction and prints
+      its details but does not interact with any wallet or send anything
+      to the network.
+
   --out-dir <path>
       Directory to write the result as a JSON file. The file
       is named set-agent-uri-<chainId>-<timestamp>.json.
@@ -161,10 +179,14 @@ Environment Variables:
                  for interactive use as the key may appear in shell history.
 
 Examples:
-  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain sepolia --keystore ~/.foundry/keystores/default
-  $ PRIVATE_KEY=0x... agently-cli set-agent-uri --agent-id 42 --uri "https://example.com/agent.json" --chain sepolia
-  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain localhost --registry 0x5FbDB2315678afecb367f032d93F642f64180aa3
-  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain sepolia --browser`,
+  # Dry-run (default) — shows encoded transaction, no wallet needed
+  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain sepolia
+
+  # Sign and broadcast
+  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain sepolia --keystore ~/.foundry/keystores/default --broadcast
+  $ PRIVATE_KEY=0x... agently-cli set-agent-uri --agent-id 42 --uri "https://example.com/agent.json" --chain sepolia --broadcast
+  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain localhost --registry 0x5FbDB2315678afecb367f032d93F642f64180aa3 --broadcast
+  $ agently-cli set-agent-uri --agent-id 1 --uri "./metadata.json" --chain sepolia --browser --broadcast`,
   )
   .action(handleAction(setAgentUri));
 

--- a/packages/agently-cli/src/wallet/index.ts
+++ b/packages/agently-cli/src/wallet/index.ts
@@ -8,6 +8,7 @@ import { CliError } from "../utils.js";
 export interface WalletOptions {
   keystore?: string;
   browser?: boolean;
+  broadcast?: boolean;
 }
 
 export type WalletMethod =


### PR DESCRIPTION
Breaking change:
add `--broadcast` option to explicitly broadcast tx. By default, it will run in dry mode.