### PR TITLE
fix: add root README to aixyz npm publish step

### DIFF
--- a/.github/workflows/publish-aixyz.yml
+++ b/.github/workflows/publish-aixyz.yml
@@ -53,6 +53,10 @@ jobs:
         working-directory: packages/aixyz
         run: bun pm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
+      - name: Copy root README
+        run: cp ../../README.md ./README.md
+        working-directory: packages/aixyz
+
       - name: Publish
         working-directory: packages/aixyz
         run: bunx npm publish --access public --tag ${{ steps.version.outputs.dist_tag }}


### PR DESCRIPTION
npm publish will drop REAME.md that's symlink. so we need to add extra cp step to copy from root README to packages/aixyz