### PR TITLE
feat: update erc8004 supported chains

### DIFF
--- a/packages/aixyz-erc-8004/README.md
+++ b/packages/aixyz-erc-8004/README.md
@@ -87,26 +87,43 @@ import { ValidationRegistryUpgradeable } from "@aixyz/erc-8004/contracts/Validat
 
 **Mainnets:**
 
-| Chain   | Chain ID | Constant           |
-| ------- | -------- | ------------------ |
-| Mainnet | `1`      | `CHAIN_ID.MAINNET` |
-| Base    | `8453`   | `CHAIN_ID.BASE`    |
-| Polygon | `137`    | `CHAIN_ID.POLYGON` |
-| Scroll  | `534352` | `CHAIN_ID.SCROLL`  |
-| Monad   | `143`    | `CHAIN_ID.MONAD`   |
-| BSC     | `56`     | `CHAIN_ID.BSC`     |
-| Gnosis  | `100`    | `CHAIN_ID.GNOSIS`  |
+| Chain     | Chain ID | Constant             |
+| --------- | -------- | -------------------- |
+| Abstract  | `2741`   | `CHAIN_ID.ABSTRACT`  |
+| Arbitrum  | `42161`  | `CHAIN_ID.ARBITRUM`  |
+| Avalanche | `43114`  | `CHAIN_ID.AVALANCHE` |
+| Base      | `8453`   | `CHAIN_ID.BASE`      |
+| BSC       | `56`     | `CHAIN_ID.BSC`       |
+| Celo      | `42220`  | `CHAIN_ID.CELO`      |
+| Gnosis    | `100`    | `CHAIN_ID.GNOSIS`    |
+| Linea     | `59144`  | `CHAIN_ID.LINEA`     |
+| Mainnet   | `1`      | `CHAIN_ID.MAINNET`   |
+| Mantle    | `5000`   | `CHAIN_ID.MANTLE`    |
+| MegaETH   | `4326`   | `CHAIN_ID.MEGAETH`   |
+| Monad     | `143`    | `CHAIN_ID.MONAD`     |
+| Optimism  | `10`     | `CHAIN_ID.OPTIMISM`  |
+| Polygon   | `137`    | `CHAIN_ID.POLYGON`   |
+| Scroll    | `534352` | `CHAIN_ID.SCROLL`    |
+| Taiko     | `167000` | `CHAIN_ID.TAIKO`     |
 
 **Testnets:**
 
-| Chain          | Chain ID   | Constant                  |
-| -------------- | ---------- | ------------------------- |
-| Sepolia        | `11155111` | `CHAIN_ID.SEPOLIA`        |
-| Base Sepolia   | `84532`    | `CHAIN_ID.BASE_SEPOLIA`   |
-| Polygon Amoy   | `80002`    | `CHAIN_ID.POLYGON_AMOY`   |
-| Scroll Sepolia | `534351`   | `CHAIN_ID.SCROLL_SEPOLIA` |
-| Monad Testnet  | `10143`    | `CHAIN_ID.MONAD_TESTNET`  |
-| BSC Testnet    | `97`       | `CHAIN_ID.BSC_TESTNET`    |
+| Chain            | Chain ID   | Constant                    |
+| ---------------- | ---------- | --------------------------- |
+| Abstract Testnet | `11124`    | `CHAIN_ID.ABSTRACT_TESTNET` |
+| Arbitrum Sepolia | `421614`   | `CHAIN_ID.ARBITRUM_SEPOLIA` |
+| Avalanche Fuji   | `43113`    | `CHAIN_ID.AVALANCHE_FUJI`   |
+| Base Sepolia     | `84532`    | `CHAIN_ID.BASE_SEPOLIA`     |
+| BSC Testnet      | `97`       | `CHAIN_ID.BSC_TESTNET`      |
+| Celo Sepolia     | `11142220` | `CHAIN_ID.CELO_SEPOLIA`     |
+| Linea Sepolia    | `59141`    | `CHAIN_ID.LINEA_SEPOLIA`    |
+| Mantle Sepolia   | `5003`     | `CHAIN_ID.MANTLE_SEPOLIA`   |
+| MegaETH Testnet  | `6342`     | `CHAIN_ID.MEGAETH_TESTNET`  |
+| Monad Testnet    | `10143`    | `CHAIN_ID.MONAD_TESTNET`    |
+| Optimism Sepolia | `11155420` | `CHAIN_ID.OPTIMISM_SEPOLIA` |
+| Polygon Amoy     | `80002`    | `CHAIN_ID.POLYGON_AMOY`     |
+| Scroll Sepolia   | `534351`   | `CHAIN_ID.SCROLL_SEPOLIA`   |
+| Sepolia          | `11155111` | `CHAIN_ID.SEPOLIA`          |
 
 ## ABIs
 
@@ -122,7 +139,7 @@ Versioned ABIs (e.g. `IdentityRegistryAbi_V1`, `ReputationRegistryAbi_V3`) are a
 
 All contracts use UUPS proxies. Addresses are consistent across all chains within each environment.
 
-**Mainnets** (Ethereum, Base, Polygon, Scroll, Monad, BSC, Gnosis):
+**Mainnets** (Abstract, Arbitrum, Avalanche, Base, BSC, Celo, Gnosis, Linea, Ethereum, Mantle, MegaETH, Monad, Optimism, Polygon, Scroll, Taiko):
 
 | Contract             | Address                                      |
 | -------------------- | -------------------------------------------- |
@@ -130,7 +147,7 @@ All contracts use UUPS proxies. Addresses are consistent across all chains withi
 | `reputationRegistry` | `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63` |
 | `validationRegistry` | `0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58` |
 
-**Testnets** (Sepolia, Base Sepolia, Polygon Amoy, Scroll Sepolia, Monad Testnet, BSC Testnet):
+**Testnets** (Abstract Testnet, Arbitrum Sepolia, Avalanche Fuji, Base Sepolia, BSC Testnet, Celo Sepolia, Linea Sepolia, Mantle Sepolia, MegaETH Testnet, Monad Testnet, Optimism Sepolia, Polygon Amoy, Scroll Sepolia, Sepolia):
 
 | Contract             | Address                                      |
 | -------------------- | -------------------------------------------- |

--- a/packages/aixyz-erc-8004/index.ts
+++ b/packages/aixyz-erc-8004/index.ts
@@ -28,20 +28,37 @@ export { ValidationRegistryAbi_V1 as ValidationRegistryAbi } from "./abis/Valida
 // Chain ID constants
 export const CHAIN_ID = {
   // Mainnets
-  MAINNET: 1,
+  ABSTRACT: 2741,
+  ARBITRUM: 42161,
+  AVALANCHE: 43114,
   BASE: 8453,
+  BSC: 56,
+  CELO: 42220,
+  GNOSIS: 100,
+  LINEA: 59144,
+  MAINNET: 1,
+  MANTLE: 5000,
+  MEGAETH: 4326,
+  MONAD: 143,
+  OPTIMISM: 10,
   POLYGON: 137,
   SCROLL: 534352,
-  MONAD: 143,
-  BSC: 56,
-  GNOSIS: 100,
+  TAIKO: 167000,
   // Testnets
-  SEPOLIA: 11155111,
+  ABSTRACT_TESTNET: 11124,
+  ARBITRUM_SEPOLIA: 421614,
+  AVALANCHE_FUJI: 43113,
   BASE_SEPOLIA: 84532,
+  BSC_TESTNET: 97,
+  CELO_SEPOLIA: 11142220,
+  LINEA_SEPOLIA: 59141,
+  MANTLE_SEPOLIA: 5003,
+  MEGAETH_TESTNET: 6342,
+  MONAD_TESTNET: 10143,
+  OPTIMISM_SEPOLIA: 11155420,
   POLYGON_AMOY: 80002,
   SCROLL_SEPOLIA: 534351,
-  MONAD_TESTNET: 10143,
-  BSC_TESTNET: 97,
+  SEPOLIA: 11155111,
 } as const;
 
 export type SupportedChainId = (typeof CHAIN_ID)[keyof typeof CHAIN_ID];
@@ -51,13 +68,79 @@ export const ADDRESSES = {
   // =============================================================================
   // Mainnets
   // =============================================================================
-  [CHAIN_ID.MAINNET]: {
+  [CHAIN_ID.ABSTRACT]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.ARBITRUM]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.AVALANCHE]: {
     identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
     reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
     // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
     validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
   },
   [CHAIN_ID.BASE]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.BSC]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.CELO]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.GNOSIS]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.LINEA]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.MAINNET]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.MANTLE]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.MEGAETH]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.MONAD]: {
+    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
+    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
+    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
+  },
+  [CHAIN_ID.OPTIMISM]: {
     identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
     reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
     // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
@@ -75,19 +158,7 @@ export const ADDRESSES = {
     // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
     validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
   },
-  [CHAIN_ID.MONAD]: {
-    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
-    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
-    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
-    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
-  },
-  [CHAIN_ID.BSC]: {
-    identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
-    reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
-    // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
-    validationRegistry: "0x8004Cc8439f36fd5F9F049D9fF86523Df6dAAB58",
-  },
-  [CHAIN_ID.GNOSIS]: {
+  [CHAIN_ID.TAIKO]: {
     identityRegistry: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
     reputationRegistry: "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
     // TODO: this contract address is not officially announced (found through deployment by same owner as the rest)
@@ -96,12 +167,57 @@ export const ADDRESSES = {
   // =============================================================================
   // Testnets
   // =============================================================================
-  [CHAIN_ID.SEPOLIA]: {
+  [CHAIN_ID.ABSTRACT_TESTNET]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.ARBITRUM_SEPOLIA]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.AVALANCHE_FUJI]: {
     identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
     reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
     validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
   },
   [CHAIN_ID.BASE_SEPOLIA]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.BSC_TESTNET]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.CELO_SEPOLIA]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.LINEA_SEPOLIA]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.MANTLE_SEPOLIA]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.MEGAETH_TESTNET]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.MONAD_TESTNET]: {
+    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
+    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
+  },
+  [CHAIN_ID.OPTIMISM_SEPOLIA]: {
     identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
     reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
     validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
@@ -116,12 +232,7 @@ export const ADDRESSES = {
     reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
     validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
   },
-  [CHAIN_ID.MONAD_TESTNET]: {
-    identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
-    reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
-    validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
-  },
-  [CHAIN_ID.BSC_TESTNET]: {
+  [CHAIN_ID.SEPOLIA]: {
     identityRegistry: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
     reputationRegistry: "0x8004B663056A597Dffe9eCcC1965A193B7388713",
     validationRegistry: "0x8004Cb1BF31DAf7788923b405b754f57acEB4272",
@@ -163,13 +274,22 @@ export function isMainnetChain(chainId: number): boolean {
   }
 
   switch (chainId) {
-    case CHAIN_ID.MAINNET:
+    case CHAIN_ID.ABSTRACT:
+    case CHAIN_ID.ARBITRUM:
+    case CHAIN_ID.AVALANCHE:
     case CHAIN_ID.BASE:
+    case CHAIN_ID.BSC:
+    case CHAIN_ID.CELO:
+    case CHAIN_ID.GNOSIS:
+    case CHAIN_ID.LINEA:
+    case CHAIN_ID.MAINNET:
+    case CHAIN_ID.MANTLE:
+    case CHAIN_ID.MEGAETH:
+    case CHAIN_ID.MONAD:
+    case CHAIN_ID.OPTIMISM:
     case CHAIN_ID.POLYGON:
     case CHAIN_ID.SCROLL:
-    case CHAIN_ID.MONAD:
-    case CHAIN_ID.BSC:
-    case CHAIN_ID.GNOSIS:
+    case CHAIN_ID.TAIKO:
       return true;
     default:
       return false;


### PR DESCRIPTION
Add support for 9 new mainnet chains (Abstract, Arbitrum, Avalanche, Celo, Linea, Mantle, MegaETH, Optimism, Taiko) and 8 new testnet chains, matching recent deployments in erc-8004-contracts.

Closes #196