### PR TITLE
feat: add agent-netintel example

### DIFF
--- a/examples/agent-netintel/README.md
+++ b/examples/agent-netintel/README.md
@@ -1,0 +1,60 @@
+# NetIntel Network Intelligence Agent
+
+A network intelligence agent powered by NetIntel x402 APIs. Extract structured data from unstructured text, look up DNS records, analyze SSL certificates, and validate email authentication — all pay-per-call via x402 on Base mainnet.
+
+## Quick Start
+
+```bash
+bun install
+
+# Create .env.local with your keys
+echo "OPENAI_API_KEY=sk-..." > .env.local
+
+bun run dev
+```
+
+## Project Structure
+
+```
+app/
+├── agent.ts            # Agent definition with all four tools
+├── tools/
+│   ├── schema-parse.ts # Extract structured data from unstructured text
+│   ├── dns-lookup.ts   # Look up DNS records for a domain
+│   ├── ssl-analyze.ts  # Analyze TLS/SSL certificates and security
+│   └── email-auth.ts   # Validate SPF, DKIM, and DMARC records
+```
+
+## Skills
+
+| Skill                       | Example                                         |
+| --------------------------- | ----------------------------------------------- |
+| Structured Data Extraction  | "Extract contact info from this email signature" |
+| DNS Lookup                  | "Look up DNS records for example.com"            |
+| SSL Analysis                | "Check SSL certificate for github.com"           |
+| Email Authentication        | "Check email security for gmail.com"             |
+
+## Environment Variables
+
+| Variable         | Description    |
+| ---------------- | -------------- |
+| `OPENAI_API_KEY` | OpenAI API key |
+
+## API Endpoints
+
+| Endpoint                       | Description           |
+| ------------------------------ | --------------------- |
+| `/.well-known/agent-card.json` | A2A agent card        |
+| `POST /agent`                  | A2A JSON-RPC endpoint |
+| `POST /mcp`                    | MCP tool endpoint     |
+
+## Payment
+
+Charges `$0.005` per request via x402 on Base (mainnet in production, Base Sepolia in development). NetIntel endpoints are pay-per-call via x402 on Base mainnet.
+
+## Build & Deploy
+
+```bash
+bun run build   # bundle for deployment
+vercel          # deploy to Vercel
+```

--- a/examples/agent-netintel/aixyz.config.ts
+++ b/examples/agent-netintel/aixyz.config.ts
@@ -1,0 +1,62 @@
+import type { AixyzConfig } from "aixyz/config";
+
+const config: AixyzConfig = {
+  name: "NetIntel Agent",
+  description:
+    "Network intelligence agent powered by NetIntel x402 API. Extract structured data from unstructured text, look up DNS records, analyze SSL certificates, validate email authentication, and check IP reputation — all pay-per-call via x402 on Base.",
+  version: "0.1.0",
+  x402: {
+    payTo: "0x0000000000000000000000000000000000000000",
+    network:
+      process.env.NODE_ENV === "production" ? "eip155:8453" : "eip155:84532",
+  },
+  skills: [
+    {
+      id: "schema-parse",
+      name: "Structured Data Extraction",
+      description:
+        "Extract structured data from any unstructured text using LLM — contacts, invoices, records, any schema you define",
+      tags: ["data", "extraction", "llm", "parsing", "structured"],
+      examples: [
+        "Extract contact info from this email signature",
+        "Pull invoice details from this block of text",
+        "Parse this job posting into structured fields",
+      ],
+    },
+    {
+      id: "dns-lookup",
+      name: "DNS Lookup",
+      description:
+        "Resolve all DNS record types for a domain, parse SPF/DKIM/DMARC, check propagation across resolvers",
+      tags: ["dns", "network", "security"],
+      examples: [
+        "Look up DNS records for example.com",
+        "Check SPF record for gmail.com",
+      ],
+    },
+    {
+      id: "ssl-analyze",
+      name: "SSL Analysis",
+      description:
+        "Analyze TLS certificate chain, supported protocols, and return an overall security grade A-F",
+      tags: ["ssl", "tls", "security", "certificate"],
+      examples: [
+        "Check SSL certificate for github.com",
+        "What TLS version does cloudflare.com use?",
+      ],
+    },
+    {
+      id: "email-auth",
+      name: "Email Authentication",
+      description:
+        "Validate SPF, DKIM, and DMARC records for a domain with multi-selector probing and security grading",
+      tags: ["email", "spf", "dkim", "dmarc", "security"],
+      examples: [
+        "Check email security for gmail.com",
+        "Does example.com have DMARC configured?",
+      ],
+    },
+  ],
+};
+
+export default config;

--- a/examples/agent-netintel/app/agent.ts
+++ b/examples/agent-netintel/app/agent.ts
@@ -1,0 +1,35 @@
+import { openai } from "@ai-sdk/openai";
+import { stepCountIs, ToolLoopAgent } from "ai";
+import type { Accepts } from "aixyz/accepts";
+
+import schemaParse from "./tools/schema-parse";
+import dnsLookup from "./tools/dns-lookup";
+import sslAnalyze from "./tools/ssl-analyze";
+import emailAuth from "./tools/email-auth";
+
+const instructions = `
+# Network Intelligence Agent
+
+You are a network intelligence assistant that can extract structured data from unstructured text and perform network/security lookups.
+
+## Guidelines
+
+- Use \`schemaParse\` to extract structured data from raw text given a target schema describing the fields to extract.
+- Use \`dnsLookup\` to resolve DNS records for a domain.
+- Use \`sslAnalyze\` to analyze TLS/SSL certificates and security for a domain.
+- Use \`emailAuth\` to validate SPF, DKIM, and DMARC email authentication records for a domain.
+- When performing network lookups, clearly present the results in a readable format.
+- If the user's request is ambiguous, ask for clarification.
+`.trim();
+
+export const accepts: Accepts = {
+  scheme: "exact",
+  price: "$0.005",
+};
+
+export default new ToolLoopAgent({
+  model: openai("gpt-4o-mini"),
+  instructions: instructions,
+  tools: { schemaParse, dnsLookup, sslAnalyze, emailAuth },
+  stopWhen: stepCountIs(10),
+});

--- a/examples/agent-netintel/app/tools/dns-lookup.ts
+++ b/examples/agent-netintel/app/tools/dns-lookup.ts
@@ -1,0 +1,15 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export default tool({
+  description: "Look up DNS records for a domain, including A, AAAA, MX, TXT, NS, CNAME, and SOA records.",
+  inputSchema: z.object({
+    domain: z.string().describe("The domain name to look up DNS records for"),
+  }),
+  execute: async ({ domain }) => {
+    const response = await fetch(
+      `https://netintel-production-440c.up.railway.app/dns/lookup?domain=${encodeURIComponent(domain)}`
+    );
+    return await response.json();
+  },
+});

--- a/examples/agent-netintel/app/tools/email-auth.ts
+++ b/examples/agent-netintel/app/tools/email-auth.ts
@@ -1,0 +1,18 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export default tool({
+  description:
+    "Validate SPF, DKIM, and DMARC email authentication records for a domain with multi-selector probing and security grading.",
+  inputSchema: z.object({
+    domain: z.string().describe("The domain name to check email authentication for"),
+  }),
+  execute: async ({ domain }) => {
+    const response = await fetch("https://netintel-production-440c.up.railway.app/email-auth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain }),
+    });
+    return await response.json();
+  },
+});

--- a/examples/agent-netintel/app/tools/schema-parse.ts
+++ b/examples/agent-netintel/app/tools/schema-parse.ts
@@ -1,0 +1,21 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export default tool({
+  description:
+    "Extract structured data from unstructured text using an LLM. Provide the raw text and a target schema describing the fields to extract.",
+  inputSchema: z.object({
+    raw_text: z.string().describe("The unstructured text to extract data from"),
+    target_schema: z
+      .record(z.string(), z.any())
+      .describe("An object describing the fields to extract and their expected types"),
+  }),
+  execute: async ({ raw_text, target_schema }) => {
+    const response = await fetch("https://netintel-production-440c.up.railway.app/schema-parse/extract", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ raw_text, target_schema }),
+    });
+    return await response.json();
+  },
+});

--- a/examples/agent-netintel/app/tools/ssl-analyze.ts
+++ b/examples/agent-netintel/app/tools/ssl-analyze.ts
@@ -1,0 +1,16 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export default tool({
+  description:
+    "Analyze the TLS/SSL certificate chain, supported protocols, and security grade for a domain.",
+  inputSchema: z.object({
+    domain: z.string().describe("The domain name to analyze SSL/TLS for"),
+  }),
+  execute: async ({ domain }) => {
+    const response = await fetch(
+      `https://netintel-production-440c.up.railway.app/ssl/analyze?domain=${encodeURIComponent(domain)}`
+    );
+    return await response.json();
+  },
+});

--- a/examples/agent-netintel/package.json
+++ b/examples/agent-netintel/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@examples/agent-netintel",
+  "private": true,
+  "scripts": {
+    "build": "aixyz build",
+    "dev": "aixyz dev"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3",
+    "ai": "^6",
+    "aixyz": "^0",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@types/bun": "^1",
+    "typescript": "^5"
+  }
+}

--- a/examples/agent-netintel/tsconfig.json
+++ b/examples/agent-netintel/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  }
+}

--- a/examples/agent-netintel/vercel.json
+++ b/examples/agent-netintel/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "bun run build"
+}


### PR DESCRIPTION
Adds a network intelligence agent example using the NetIntel x402 API.

The agent demonstrates:
- Structured data extraction from unstructured text via /schema-parse/extract
- DNS record lookup via /dns/lookup
- SSL certificate analysis via /ssl/analyze
- Email authentication validation (SPF/DKIM/DMARC) via /email-auth

All endpoints are pay-per-call via x402 on Base mainnet. No API keys required.

NetIntel API: https://netintel-production-440c.up.railway.app/.well-known/x402
Docs: https://github.com/kjgueye/netintel-api