### PR TITLE
feat: add Solana (SVM) x402 payment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ That's it. Run `bun run dev` and aixyz auto-generates the server, wires up A2A +
 | [`flight-search`](./examples/flight-search/)                     | Flight search with Stripe payments              |
 | [`local-llm`](./examples/local-llm/)                             | Local LLM via Docker (no external API)          |
 | [`with-custom-facilitator`](./examples/with-custom-facilitator/) | Bring-your-own x402 facilitator                 |
+| [`with-solana`](./examples/with-solana/)                         | x402 payments in USDC on Solana                 |
 | [`with-custom-server`](./examples/with-custom-server/)           | Custom server setup                             |
 | [`with-express`](./examples/with-express/)                       | Express middleware integration                  |
 | [`sub-agents`](./examples/sub-agents/)                           | Multiple A2A endpoints from one deployment      |
@@ -161,7 +162,7 @@ See the [CLI reference](https://aixyz.sh/packages/aixyz) for all options.
 
 **MCP (Model Context Protocol)** — Expose tools to any MCP client (Claude Desktop, VS Code, Cursor).
 
-**x402** — HTTP 402 micropayments. Per-request payment with cryptographic proof, verified on-chain.
+**x402** — HTTP 402 micropayments. Per-request payment with cryptographic proof, verified on-chain across EVM chains and Solana.
 
 **ERC-8004** — On-chain agent identity on Ethereum, Base, Polygon, Scroll, Monad, BSC, or Gnosis.
 

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,19 @@
         "x402-fl": "^0",
       },
     },
+    "examples/with-solana": {
+      "name": "@examples/with-solana",
+      "dependencies": {
+        "@ai-sdk/openai": "^3",
+        "ai": "^6",
+        "aixyz": "^0",
+        "zod": "^4",
+      },
+      "devDependencies": {
+        "@types/bun": "^1",
+        "typescript": "^6",
+      },
+    },
     "examples/with-tests": {
       "name": "@examples/with-tests",
       "dependencies": {
@@ -208,9 +221,11 @@
         "@kitajs/html": "^4.2.13",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@next/env": "^16.1.6",
+        "@solana/kit": "^5.1.0",
         "@x402/core": "^2.3.1",
         "@x402/evm": "^2.3.1",
         "@x402/mcp": "^2.3.0",
+        "@x402/svm": "2.6.0",
         "jose": "^6.1.3",
         "zod": "^4",
       },
@@ -399,6 +414,8 @@
     "@examples/with-custom-server": ["@examples/with-custom-server@workspace:examples/with-custom-server"],
 
     "@examples/with-express": ["@examples/with-express@workspace:examples/with-express"],
+
+    "@examples/with-solana": ["@examples/with-solana@workspace:examples/with-solana"],
 
     "@examples/with-tests": ["@examples/with-tests@workspace:examples/with-tests"],
 
@@ -604,6 +621,90 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@solana-program/compute-budget": ["@solana-program/compute-budget@0.11.0", "", { "peerDependencies": { "@solana/kit": "^5.0" } }, "sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw=="],
+
+    "@solana-program/token": ["@solana-program/token@0.9.0", "", { "peerDependencies": { "@solana/kit": "^5.0" } }, "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA=="],
+
+    "@solana-program/token-2022": ["@solana-program/token-2022@0.6.1", "", { "peerDependencies": { "@solana/kit": "^5.0", "@solana/sysvars": "^5.0" } }, "sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA=="],
+
+    "@solana/accounts": ["@solana/accounts@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ=="],
+
+    "@solana/addresses": ["@solana/addresses@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA=="],
+
+    "@solana/assertions": ["@solana/assertions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q=="],
+
+    "@solana/codecs": ["@solana/codecs@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/options": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g=="],
+
+    "@solana/codecs-core": ["@solana/codecs-core@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw=="],
+
+    "@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w=="],
+
+    "@solana/codecs-numbers": ["@solana/codecs-numbers@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw=="],
+
+    "@solana/codecs-strings": ["@solana/codecs-strings@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": "^5.0.0" }, "optionalPeers": ["fastestsmallesttextencoderdecoder", "typescript"] }, "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A=="],
+
+    "@solana/errors": ["@solana/errors@5.5.1", "", { "dependencies": { "chalk": "5.6.2", "commander": "14.0.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "errors": "bin/cli.mjs" } }, "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg=="],
+
+    "@solana/fast-stable-stringify": ["@solana/fast-stable-stringify@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw=="],
+
+    "@solana/functional": ["@solana/functional@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w=="],
+
+    "@solana/instruction-plans": ["@solana/instruction-plans@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/promises": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ=="],
+
+    "@solana/instructions": ["@solana/instructions@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ=="],
+
+    "@solana/keys": ["@solana/keys@5.5.1", "", { "dependencies": { "@solana/assertions": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg=="],
+
+    "@solana/kit": ["@solana/kit@5.5.1", "", { "dependencies": { "@solana/accounts": "5.5.1", "@solana/addresses": "5.5.1", "@solana/codecs": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instruction-plans": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/offchain-messages": "5.5.1", "@solana/plugin-core": "5.5.1", "@solana/programs": "5.5.1", "@solana/rpc": "5.5.1", "@solana/rpc-api": "5.5.1", "@solana/rpc-parsed-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-subscriptions": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/signers": "5.5.1", "@solana/sysvars": "5.5.1", "@solana/transaction-confirmation": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ=="],
+
+    "@solana/nominal-types": ["@solana/nominal-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ=="],
+
+    "@solana/offchain-messages": ["@solana/offchain-messages@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw=="],
+
+    "@solana/options": ["@solana/options@5.5.1", "", { "dependencies": { "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A=="],
+
+    "@solana/plugin-core": ["@solana/plugin-core@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A=="],
+
+    "@solana/programs": ["@solana/programs@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA=="],
+
+    "@solana/promises": ["@solana/promises@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA=="],
+
+    "@solana/rpc": ["@solana/rpc@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/fast-stable-stringify": "5.5.1", "@solana/functional": "5.5.1", "@solana/rpc-api": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-transport-http": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A=="],
+
+    "@solana/rpc-api": ["@solana/rpc-api@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/rpc-parsed-types": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA=="],
+
+    "@solana/rpc-parsed-types": ["@solana/rpc-parsed-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg=="],
+
+    "@solana/rpc-spec": ["@solana/rpc-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q=="],
+
+    "@solana/rpc-spec-types": ["@solana/rpc-spec-types@5.5.1", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw=="],
+
+    "@solana/rpc-subscriptions": ["@solana/rpc-subscriptions@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/fast-stable-stringify": "5.5.1", "@solana/functional": "5.5.1", "@solana/promises": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-subscriptions-api": "5.5.1", "@solana/rpc-subscriptions-channel-websocket": "5.5.1", "@solana/rpc-subscriptions-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/subscribable": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w=="],
+
+    "@solana/rpc-subscriptions-api": ["@solana/rpc-subscriptions-api@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/keys": "5.5.1", "@solana/rpc-subscriptions-spec": "5.5.1", "@solana/rpc-transformers": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw=="],
+
+    "@solana/rpc-subscriptions-channel-websocket": ["@solana/rpc-subscriptions-channel-websocket@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/rpc-subscriptions-spec": "5.5.1", "@solana/subscribable": "5.5.1", "ws": "^8.19.0" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ=="],
+
+    "@solana/rpc-subscriptions-spec": ["@solana/rpc-subscriptions-spec@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/promises": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/subscribable": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ=="],
+
+    "@solana/rpc-transformers": ["@solana/rpc-transformers@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q=="],
+
+    "@solana/rpc-transport-http": ["@solana/rpc-transport-http@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1", "@solana/rpc-spec": "5.5.1", "@solana/rpc-spec-types": "5.5.1", "undici-types": "^7.19.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg=="],
+
+    "@solana/rpc-types": ["@solana/rpc-types@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/nominal-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA=="],
+
+    "@solana/signers": ["@solana/signers@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/errors": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/offchain-messages": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ=="],
+
+    "@solana/subscribable": ["@solana/subscribable@5.5.1", "", { "dependencies": { "@solana/errors": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ=="],
+
+    "@solana/sysvars": ["@solana/sysvars@5.5.1", "", { "dependencies": { "@solana/accounts": "5.5.1", "@solana/codecs": "5.5.1", "@solana/errors": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA=="],
+
+    "@solana/transaction-confirmation": ["@solana/transaction-confirmation@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/keys": "5.5.1", "@solana/promises": "5.5.1", "@solana/rpc": "5.5.1", "@solana/rpc-subscriptions": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1", "@solana/transactions": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw=="],
+
+    "@solana/transaction-messages": ["@solana/transaction-messages@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ=="],
+
+    "@solana/transactions": ["@solana/transactions@5.5.1", "", { "dependencies": { "@solana/addresses": "5.5.1", "@solana/codecs-core": "5.5.1", "@solana/codecs-data-structures": "5.5.1", "@solana/codecs-numbers": "5.5.1", "@solana/codecs-strings": "5.5.1", "@solana/errors": "5.5.1", "@solana/functional": "5.5.1", "@solana/instructions": "5.5.1", "@solana/keys": "5.5.1", "@solana/nominal-types": "5.5.1", "@solana/rpc-types": "5.5.1", "@solana/transaction-messages": "5.5.1" }, "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA=="],
+
     "@spruceid/siwe-parser": ["@spruceid/siwe-parser@2.1.2", "", { "dependencies": { "@noble/hashes": "^1.1.2", "apg-js": "^4.3.0", "uri-js": "^4.4.1", "valid-url": "^1.0.9" } }, "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ=="],
 
     "@stablelib/binary": ["@stablelib/binary@1.0.1", "", { "dependencies": { "@stablelib/int": "^1.0.1" } }, "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q=="],
@@ -681,6 +782,8 @@
     "@x402/fetch": ["@x402/fetch@2.6.0", "", { "dependencies": { "@x402/core": "~2.6.0", "viem": "^2.39.3", "zod": "^3.24.2" } }, "sha512-OnHXw/mv76ig4UBJEgfQIWHSWcrgIOT2i8RxEuGl12QtaYwSgBcgDub2GdllL/iIB9OneM1m0UWlrPh23JdVjQ=="],
 
     "@x402/mcp": ["@x402/mcp@2.6.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.12.1", "@x402/core": "~2.6.0", "zod": "^3.24.2" } }, "sha512-jT9BqwwSajFaRcW/LIKIGI3kdoQt85JuDrBYFIgu9tyfja0GsHcH78GYBcG/WIlrkgpjBTSJxAW7H4QmgE58Mw=="],
+
+    "@x402/svm": ["@x402/svm@2.6.0", "", { "dependencies": { "@solana-program/compute-budget": "^0.11.0", "@solana-program/token": "^0.9.0", "@solana-program/token-2022": "^0.6.1", "@x402/core": "~2.6.0" }, "peerDependencies": { "@solana/kit": ">=5.1.0" } }, "sha512-SayKQSpN82XQ3qq46d1p348z+nPrYa9SyJ2MXfhwqmGE6JeEd2d0tSUpmghUKjucG8HZ1H4Man9yp/b/9cQZxg=="],
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
@@ -1407,6 +1510,12 @@
     "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@solana/errors/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "@solana/rpc-subscriptions-channel-websocket/ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "@solana/rpc-transport-http/undici-types": ["undici-types@7.28.0", "", {}, "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ=="],
 
     "@spruceid/siwe-parser/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,7 @@
               "templates/advanced/sub-agents",
               "templates/advanced/with-custom-server",
               "templates/advanced/with-custom-facilitator",
+              "templates/advanced/with-solana",
               "templates/advanced/with-tests",
               "templates/advanced/fake-llm",
               "templates/advanced/with-express",

--- a/docs/getting-started/payments.mdx
+++ b/docs/getting-started/payments.mdx
@@ -97,22 +97,37 @@ export const accepts: Accepts = [
 
 ## Payment Networks
 
-Configure the payment network in `aixyz.config.ts`:
+Configure the payment network in `aixyz.config.ts`. Networks are [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) identifiers — EVM chains use the `eip155:*` namespace, Solana uses `solana:*`:
 
-| Network      | CAIP-2 ID      |
-| ------------ | -------------- |
-| Base         | `eip155:8453`  |
-| Base Sepolia | `eip155:84532` |
-| Ethereum     | `eip155:1`     |
+| Network             | CAIP-2 ID                                 |
+| ------------------- | ----------------------------------------- |
+| Base                | `eip155:8453`                             |
+| Base Sepolia        | `eip155:84532`                            |
+| Ethereum            | `eip155:1`                                |
+| Solana mainnet-beta | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
+| Solana devnet       | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+
+aixyz registers the correct payment scheme (EVM or Solana) automatically from the network's namespace — no extra setup. On Solana, prices settle as USDC and `payTo` is a base58 wallet address (not `0x...`).
 
 Switch networks per environment:
 
 ```typescript
+// EVM
 x402: {
   payTo: "0x...",
   network: process.env.NODE_ENV === "production" ? "eip155:8453" : "eip155:84532",
 },
+
+// Solana
+x402: {
+  payTo: "So1111...", // base58 wallet address
+  network: process.env.NODE_ENV === "production"
+    ? "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+    : "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+},
 ```
+
+See the [Solana Agent template](/templates/advanced/with-solana) for a working example.
 
 ## Facilitators
 
@@ -123,6 +138,8 @@ Payment verification is handled by a facilitator service:
 | Default      | Always available             | `https://x402.use-agently.com/facilitator` |
 | Coinbase CDP | When `CDP_API_KEY_ID` is set | Auto-configured                            |
 | Custom       | Set `X402_FACILITATOR_URL`   | Your custom URL                            |
+
+The default facilitator settles on both EVM chains and Solana. To settle Solana payments elsewhere, point `X402_FACILITATOR_URL` at any Solana-capable facilitator — for example [PayAI](https://facilitator.payai.network).
 
 ### Custom Facilitator
 

--- a/docs/protocols/x402.mdx
+++ b/docs/protocols/x402.mdx
@@ -44,6 +44,20 @@ export const accepts: Accepts = {
 
 Prices are USD strings: `"$0.005"`, `"$0.01"`, `"$0.0001"`.
 
+### Networks
+
+The `network` is a [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) identifier. aixyz supports both EVM chains (`eip155:*`, e.g. `eip155:8453` for Base) and Solana (`solana:*`), selecting the correct payment scheme automatically:
+
+```typescript
+export const accepts: Accepts = {
+  scheme: "exact",
+  price: "$0.005",
+  network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", // Solana mainnet-beta
+};
+```
+
+On Solana, prices settle as USDC and `payTo` is a base58 address. See the [Solana Agent template](/templates/advanced/with-solana).
+
 ## Per-Agent and Per-Tool Pricing
 
 Agents and tools can each declare their own `accepts` export, enabling granular pricing:

--- a/docs/templates/advanced/with-solana.mdx
+++ b/docs/templates/advanced/with-solana.mdx
@@ -1,0 +1,80 @@
+---
+title: "Solana Agent"
+description: "Template for an x402 agent that gets paid in USDC on Solana"
+---
+
+<Info>**Source:** [`examples/with-solana`](https://github.com/AgentlyHQ/aixyz/tree/main/examples/with-solana)</Info>
+
+## Overview
+
+This template demonstrates an agent that accepts x402 payments in **USDC on Solana**. Solana networks are configured exactly like EVM chains — as CAIP-2 identifiers in `aixyz.config.ts` — and aixyz registers the Solana (SVM) payment scheme automatically.
+
+## Project Structure
+
+```
+with-solana/
+├── aixyz.config.ts           # Agent metadata + Solana network
+├── app/
+│   ├── agent.ts              # Agent with a SOL/lamports tool
+│   ├── accepts.ts            # Facilitator configuration (PayAI)
+│   └── tools/
+│       └── sol-lamports.ts   # SOL ⇄ lamports converter
+├── package.json
+└── vercel.json
+```
+
+## Solana Network
+
+Set a `solana:*` network and a base58 `payTo` wallet in `aixyz.config.ts`:
+
+```typescript title="aixyz.config.ts"
+x402: {
+  payTo: process.env.X402_PAY_TO ?? "So11111111111111111111111111111111111111112",
+  network: process.env.NODE_ENV === "production"
+    ? "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" // Solana mainnet-beta
+    : "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // Solana devnet
+},
+```
+
+That is the only change from an EVM agent — aixyz picks the SVM `exact` scheme from the `solana:` namespace.
+
+## Facilitator
+
+`app/accepts.ts` points payment verification at a Solana-capable facilitator:
+
+```typescript title="app/accepts.ts"
+import { HTTPFacilitatorClient } from "aixyz/accepts";
+
+export const facilitator = new HTTPFacilitatorClient({
+  url: process.env.X402_FACILITATOR_URL ?? "https://facilitator.payai.network",
+});
+```
+
+aixyz's default facilitator also settles Solana, so `app/accepts.ts` is optional.
+
+## Key Features
+
+- **Solana payments** — Charge and settle in USDC on Solana via x402
+- **CAIP-2 config** — Same `network` field as EVM; no special Solana wiring
+- **Auto scheme selection** — `solana:*` → SVM scheme, `eip155:*` → EVM scheme
+- **BYO facilitator** — Point at PayAI, the default, or any x402-compatible service
+
+## Payment
+
+The agent charges `$0.005` per request, settled as USDC on Solana.
+
+## Environment Variables
+
+| Variable               | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| `OPENAI_API_KEY`       | OpenAI API key                                                  |
+| `X402_PAY_TO`          | Solana wallet (base58) to receive payments                      |
+| `X402_FACILITATOR_URL` | Custom facilitator URL (defaults to PayAI's Solana facilitator) |
+
+## Running
+
+```bash
+cd examples/with-solana
+bun install
+bun run dev
+```

--- a/examples/with-solana/.gitignore
+++ b/examples/with-solana/.gitignore
@@ -1,0 +1,12 @@
+# dependencies
+node_modules
+.pnp
+.pnp.js
+.yarn*
+pnpm-lock.yaml
+
+# aixyz
+.aixyz
+
+# local env files
+.env.local

--- a/examples/with-solana/README.md
+++ b/examples/with-solana/README.md
@@ -1,0 +1,89 @@
+# Solana Agent
+
+An x402 agent that gets **paid in USDC on Solana**. Solana networks are configured exactly like EVM chains — as CAIP-2 identifiers in `aixyz.config.ts` — and aixyz registers the correct payment scheme automatically.
+
+## Quick Start
+
+```bash
+bun install
+
+# Create .env.local with your keys
+echo "OPENAI_API_KEY=sk-..." > .env.local
+
+bun run dev
+```
+
+## Project Structure
+
+```
+app/
+├── agent.ts               # Agent with a SOL/lamports conversion tool
+├── accepts.ts             # Facilitator configuration (PayAI)
+└── tools/
+    └── sol-lamports.ts    # SOL ⇄ lamports converter
+```
+
+## How It Works
+
+Set a Solana network (and a base58 `payTo` wallet) in `aixyz.config.ts`:
+
+```typescript
+x402: {
+  payTo: process.env.X402_PAY_TO ?? "So11111111111111111111111111111111111111112",
+  network:
+    process.env.NODE_ENV === "production"
+      ? "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" // Solana mainnet-beta
+      : "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // Solana devnet
+},
+```
+
+That's the only difference from an EVM agent. When a `solana:*` network is configured (or referenced in a route's
+`accepts`), aixyz registers the SVM `exact` scheme instead of the EVM one.
+
+`app/accepts.ts` points payment verification at [PayAI's facilitator](https://facilitator.payai.network), which
+settles x402 payments on Solana:
+
+```typescript
+import { HTTPFacilitatorClient } from "aixyz/accepts";
+
+export const facilitator = new HTTPFacilitatorClient({
+  url: process.env.X402_FACILITATOR_URL ?? "https://facilitator.payai.network",
+});
+```
+
+aixyz's default facilitator (`https://x402.use-agently.com/facilitator`) also settles Solana, so `app/accepts.ts` is
+optional — override `X402_FACILITATOR_URL` to point at any x402-compatible service.
+
+## Solana Networks
+
+| Network             | CAIP-2 ID                                 |
+| ------------------- | ----------------------------------------- |
+| Solana mainnet-beta | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
+| Solana devnet       | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+
+## Environment Variables
+
+| Variable               | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| `OPENAI_API_KEY`       | OpenAI API key                                                  |
+| `X402_PAY_TO`          | Solana wallet (base58) to receive payments                      |
+| `X402_FACILITATOR_URL` | Custom facilitator URL (defaults to PayAI's Solana facilitator) |
+
+## API Endpoints
+
+| Endpoint                       | Description           |
+| ------------------------------ | --------------------- |
+| `/.well-known/agent-card.json` | A2A agent card        |
+| `POST /agent`                  | A2A JSON-RPC endpoint |
+| `POST /mcp`                    | MCP tool endpoint     |
+
+## Payment
+
+Charges `$0.005` per request, settled as USDC on Solana via x402.
+
+## Build & Deploy
+
+```bash
+bun run build
+vercel
+```

--- a/examples/with-solana/aixyz.config.ts
+++ b/examples/with-solana/aixyz.config.ts
@@ -1,0 +1,18 @@
+import type { AixyzConfig } from "aixyz/config";
+
+const config: AixyzConfig = {
+  name: "Solana Agent",
+  description: "An x402 agent that gets paid in USDC on Solana.",
+  version: "0.1.0",
+  x402: {
+    // The Solana wallet (base58) that receives payments. Replace with your own, or set X402_PAY_TO.
+    payTo: process.env.X402_PAY_TO ?? "So11111111111111111111111111111111111111112",
+    // Solana networks are CAIP-2 identifiers, just like EVM chains.
+    network:
+      process.env.NODE_ENV === "production"
+        ? "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" // Solana mainnet-beta
+        : "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // Solana devnet
+  },
+};
+
+export default config;

--- a/examples/with-solana/app/accepts.ts
+++ b/examples/with-solana/app/accepts.ts
@@ -1,0 +1,8 @@
+import { HTTPFacilitatorClient } from "aixyz/accepts";
+
+// PayAI's facilitator verifies and settles x402 payments on Solana (and many EVM chains).
+// aixyz's default facilitator (https://x402.use-agently.com/facilitator) also settles Solana —
+// override with X402_FACILITATOR_URL to point at any x402-compatible service.
+export const facilitator = new HTTPFacilitatorClient({
+  url: process.env.X402_FACILITATOR_URL ?? "https://facilitator.payai.network",
+});

--- a/examples/with-solana/app/agent.ts
+++ b/examples/with-solana/app/agent.ts
@@ -1,0 +1,18 @@
+import { openai } from "@ai-sdk/openai";
+import { stepCountIs, ToolLoopAgent } from "ai";
+import type { Accepts } from "aixyz/accepts";
+
+import solLamports from "./tools/sol-lamports";
+
+// Price is a USD string — the facilitator settles it as USDC on the configured Solana network.
+export const accepts: Accepts = {
+  scheme: "exact",
+  price: "$0.005",
+};
+
+export default new ToolLoopAgent({
+  model: openai("gpt-4o-mini"),
+  instructions: "Solana Agent",
+  tools: { solLamports },
+  stopWhen: stepCountIs(10),
+});

--- a/examples/with-solana/app/tools/sol-lamports.ts
+++ b/examples/with-solana/app/tools/sol-lamports.ts
@@ -1,0 +1,18 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const LAMPORTS_PER_SOL = 1_000_000_000;
+
+export default tool({
+  description: "Convert an amount between SOL and lamports (1 SOL = 1,000,000,000 lamports).",
+  inputSchema: z.object({
+    amount: z.number().describe("The numeric amount to convert."),
+    from: z.enum(["SOL", "lamports"]).describe("The unit of the input amount."),
+  }),
+  execute: async ({ amount, from }) => {
+    if (from === "SOL") {
+      return { amount, from, to: "lamports", result: Math.round(amount * LAMPORTS_PER_SOL) };
+    }
+    return { amount, from, to: "SOL", result: amount / LAMPORTS_PER_SOL };
+  },
+});

--- a/examples/with-solana/package.json
+++ b/examples/with-solana/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@examples/with-solana",
+  "private": true,
+  "scripts": {
+    "build": "aixyz build",
+    "dev": "aixyz dev"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3",
+    "ai": "^6",
+    "aixyz": "^0",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@types/bun": "^1",
+    "typescript": "^6"
+  }
+}

--- a/examples/with-solana/tsconfig.json
+++ b/examples/with-solana/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  }
+}

--- a/examples/with-solana/vercel.json
+++ b/examples/with-solana/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "bun run build"
+}

--- a/packages/aixyz/app/payment/payment.ts
+++ b/packages/aixyz/app/payment/payment.ts
@@ -8,9 +8,17 @@ import {
   type HTTPResponseInstructions,
 } from "@x402/core/http";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { ExactSvmScheme } from "@x402/svm/exact/server";
 import type { AcceptsX402, AcceptsX402Multi } from "../../accepts";
 import { normalizeAcceptsX402 } from "../../accepts";
-import { Network, PaymentPayload, PaymentRequirements, VerifyResponse, SettleResponse } from "@x402/core/types";
+import {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  VerifyResponse,
+  SettleResponse,
+  SchemeNetworkServer,
+} from "@x402/core/types";
 import { AixyzConfig } from "@aixyz/config";
 
 // ── x402 Lifecycle Hook Types ──────────────────────────────────────────
@@ -99,6 +107,15 @@ export interface PaymentContext {
 }
 
 /**
+ * Selects the exact-scheme server implementation for a network from its CAIP-2 namespace.
+ * Solana networks (`solana:*`) use the SVM scheme; everything else (`eip155:*`, ...) uses the EVM scheme.
+ */
+export function schemeForNetwork(network: Network): SchemeNetworkServer {
+  const namespace = network.split(":")[0];
+  return namespace === "solana" ? new ExactSvmScheme() : new ExactEvmScheme();
+}
+
+/**
  * Thin wrapper around x402HTTPResourceServer
  */
 export class PaymentGateway {
@@ -125,9 +142,9 @@ export class PaymentGateway {
     });
   }
 
-  /** Register an EVM payment scheme for the given network (e.g. Base mainnet). */
+  /** Register the exact-scheme server for the given network, selected by its CAIP-2 namespace (EVM or SVM). */
   register(network: Network) {
-    this.resourceServer.register(network, new ExactEvmScheme());
+    this.resourceServer.register(network, schemeForNetwork(network));
   }
 
   /** Returns the canonical lookup key for a payment route (e.g. "POST /agent"). */

--- a/packages/aixyz/app/payment/scheme.test.ts
+++ b/packages/aixyz/app/payment/scheme.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { ExactSvmScheme } from "@x402/svm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+import { PaymentGateway, schemeForNetwork } from "./payment";
+import type { AixyzConfig } from "@aixyz/config";
+
+// CAIP-2 identifiers for Solana (genesis-hash references) — mainnet and devnet.
+const SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+const SOLANA_DEVNET = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1";
+
+describe("schemeForNetwork", () => {
+  test("selects the SVM scheme for Solana (solana:*) networks", () => {
+    expect(schemeForNetwork(SOLANA_MAINNET)).toBeInstanceOf(ExactSvmScheme);
+    expect(schemeForNetwork(SOLANA_DEVNET)).toBeInstanceOf(ExactSvmScheme);
+  });
+
+  test("selects the EVM scheme for eip155:* networks", () => {
+    expect(schemeForNetwork("eip155:8453")).toBeInstanceOf(ExactEvmScheme); // Base
+    expect(schemeForNetwork("eip155:84532")).toBeInstanceOf(ExactEvmScheme); // Base Sepolia
+    expect(schemeForNetwork("eip155:1")).toBeInstanceOf(ExactEvmScheme); // Ethereum
+  });
+
+  test("both schemes expose the exact scheme name", () => {
+    expect(schemeForNetwork(SOLANA_MAINNET).scheme).toBe("exact");
+    expect(schemeForNetwork("eip155:8453").scheme).toBe("exact");
+  });
+});
+
+describe("PaymentGateway.register", () => {
+  const config = {
+    x402: { payTo: "receiver", network: SOLANA_MAINNET },
+  } as unknown as AixyzConfig;
+
+  // A non-network-touching facilitator is enough — register() only wires schemes onto the resource server.
+  const facilitator = new HTTPFacilitatorClient({ url: "http://localhost:0" });
+
+  test("registers a scheme for a Solana network", () => {
+    const gateway = new PaymentGateway(facilitator, config);
+    gateway.register(SOLANA_MAINNET);
+    expect(gateway.resourceServer.hasRegisteredScheme(SOLANA_MAINNET, "exact")).toBe(true);
+  });
+
+  test("registers a scheme for an EVM network", () => {
+    const gateway = new PaymentGateway(facilitator, config);
+    gateway.register("eip155:8453");
+    expect(gateway.resourceServer.hasRegisteredScheme("eip155:8453", "exact")).toBe(true);
+  });
+});

--- a/packages/aixyz/package.json
+++ b/packages/aixyz/package.json
@@ -47,9 +47,11 @@
     "@kitajs/html": "^4.2.13",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@next/env": "^16.1.6",
+    "@solana/kit": "^5.1.0",
     "@x402/core": "^2.3.1",
     "@x402/evm": "^2.3.1",
     "@x402/mcp": "^2.3.0",
+    "@x402/svm": "2.6.0",
     "jose": "^6.1.3",
     "zod": "^4"
   },


### PR DESCRIPTION
## Summary

Adds Solana support to x402 payments. Today `PaymentGateway` registers the EVM `exact` scheme for **every** network, so a `solana:*` route can never verify or settle. This selects the scheme by CAIP-2 namespace instead:

```ts
export function schemeForNetwork(network: Network): SchemeNetworkServer {
  const namespace = network.split(":")[0];
  return namespace === "solana" ? new ExactSvmScheme() : new ExactEvmScheme();
}
```

Everything else was already network-agnostic — config networks are CAIP-2 strings, multi-network routes landed in #317, and the default facilitator (`x402.use-agently.com`) already settles Solana. This one choke point was the only blocker.

## Changes

- **`packages/aixyz/app/payment/payment.ts`** — `schemeForNetwork()` helper; `register()` routes through it (`solana:*` → `ExactSvmScheme`, else `ExactEvmScheme`).
- **`packages/aixyz/package.json`** — add `@x402/svm` + its `@solana/kit` peer.
- **`packages/aixyz/app/payment/scheme.test.ts`** — container-free unit test for scheme selection + registration.
- **`examples/with-solana/`** — a USDC-on-Solana agent (uses [PayAI's](https://facilitator.payai.network) Solana facilitator via `app/accepts.ts`).
- **docs** — Solana rows/notes in `payments.mdx` and `x402.mdx`, plus a new template page.

## Verified end-to-end

Built the example and hit `POST /agent` on the running server — it returns a correct Solana 402:

```json
{
  "scheme": "exact",
  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
  "amount": "5000",
  "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
  "payTo": "So1111...112",
  "extra": { "feePayer": "2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4" }
}
```

`$0.005` correctly resolved to `5000` units of Solana USDC, and the `feePayer` was fetched live from the facilitator's `/supported`.

- `bun test` (full `aixyz` suite, incl. the EVM testcontainer flow): **238 pass / 0 fail**
- `bunx tsc --noEmit`: clean · `prettier --check .`: clean

## Notes for reviewers

- **`@x402/svm` is pinned to `2.6.0`** to match the currently-locked `@x402/core@2.6.0`. A caret range resolves `@x402/svm@2.19.0`, which pulls a **second** copy of `@x402/core@2.19.0` into the tree (schemes then fail `instanceof`/registry checks against core 2.6.0). When you next bump the `@x402/*` stack, bump `svm` in lockstep. `@solana/kit` is pinned to `^5` so it satisfies both `@x402/svm` (`>=5.1.0`) and the `@solana-program/*` peers (`^5.0`).
- **Bundle size:** `payment.ts` imports `@x402/svm/exact/server` statically (same as the existing EVM import), so EVM-only agents bundle `@x402/svm` + `@solana/kit`. Kept it symmetric with the EVM path for a minimal diff — happy to lazy-load the Solana scheme (only when a `solana:*` network is registered) if you'd prefer to keep EVM-only bundles lean.
- **`app/accepts.ts` in the example points at PayAI**, but it's optional — the default facilitator settles Solana too. Swap via `X402_FACILITATOR_URL`.
- The `bun.lock` diff is additive (`@solana/*`, `@x402/svm`, and their transitive `ws`/`commander`/`undici-types`). Heads up: your committed lock is already stale vs `examples/*/package.json` for `@huggingface/transformers` (they declare `^4` since #325, the lock has `3.8.1`); I kept that out of this PR so the diff stays Solana-only.
